### PR TITLE
Bomb logic 

### DIFF
--- a/css/entrancestyle.css
+++ b/css/entrancestyle.css
@@ -217,27 +217,23 @@ body {
 }
 
 .crossedleft {
-    background: 
-       linear-gradient(to top left,
-           rgba(0,0,0,0) 0%,
-           rgba(0,0,0,0) calc(50% - 2px),
-           rgba(0,255,255,1) 50%,
-           rgba(0,0,0,0) calc(50% + 2px),
-           rgba(0,0,0,0) 100%);
-   min-height: 2px;
-   min-width: 2px;
+  background: 
+     linear-gradient(to top left,
+         rgba(0,0,0,0) calc(50% - 1px),
+         rgba(0,255,255,1) calc(50% - 0.5px) calc(50% + 0.5px),
+         rgba(0,0,0,0) calc(50% + 1px));
+ min-height: 2px;
+ min-width: 2px;
 }
 
 .crossedright {
-    background: 
-       linear-gradient(to top right,
-           rgba(0,0,0,0) 0%,
-           rgba(0,0,0,0) calc(50% - 2px),
-           rgba(0,255,255,1) 50%,
-           rgba(0,0,0,0) calc(50% + 2px),
-           rgba(0,0,0,0) 100%);
-   min-height: 2px;
-   min-width: 2px;
+  background: 
+     linear-gradient(to top right,
+         rgba(0,0,0,0) calc(50% - 1px),
+         rgba(0,255,255,1) calc(50% - 0.5px) calc(50% + 0.5px),
+         rgba(0,0,0,0) calc(50% + 1px));
+ min-height: 2px;
+ min-width: 2px;
 }
 
 .informationdiv {

--- a/css/style.css
+++ b/css/style.css
@@ -167,6 +167,7 @@ body {
 .possible { background-color: yellow; }
 .information { background-color: orange; }
 .darkavailable { background-color: blue; }
+.partialavailable { background-color: rgb(23, 170, 238); }
 .darkpossible { background-color: purple; } 
 .opened { background-color: #7f7f7f; }
 .hidden { width: 0px!important; height: 0px!important; }

--- a/js/chests.js
+++ b/js/chests.js
@@ -32,6 +32,7 @@
     function melee_bow() { return melee() || items.bow > 0; }
     function cane() { return items.somaria || items.byrna; }
     function rod() { return items.firerod || items.icerod; }
+	function canHitSwitch() { return (melee_bow() || cane() || rod() || items.boomerang || items.hookshot || items.bomb); }	
 	function agatowerweapon() { return items.sword > 0 || items.somaria || items.bow > 0 || items.hammer || items.firerod || (items.byrna && (items.bottle > 0 || items.magic)); }
 	function isdarkdm() { return !items.flute && !items.lantern; }
     function always() { return 'available'; }
@@ -228,7 +229,7 @@
 					if ((crystalCheck() < flags.ganonvulncount && flags.goals != 'A') || (!items.agahnim2 && flags.goals != 'F') || !canReachNEDW() || (flags.goals === 'A' && (!items.agahnim || !allDungeonCheck()))) return 'unavailable';
 					if ((flags.swordmode != 'S' && items.sword < 2) || (flags.swordmode === 'S' && !items.hammer) || (!items.lantern && !items.firerod)) return 'unavailable';
 					//Fast Ganon
-					if (flags.goals === 'F' && (items.sword > 1 || flags.swordmode === 'S' && (items.hammer || items.net)) && (items.lantern || items.firerod)) return 'available';
+					if (flags.goals === 'F' && (items.sword > 1 || (flags.swordmode === 'S' && (items.hammer || items.net))) && (items.lantern || items.firerod)) return 'available';
 					return window.GTBoss();
 				},
 				can_get_chest: function() {
@@ -1074,7 +1075,7 @@
 				is_beatable: function() {
 					//if (!canReachLightWorldBunny() || !items.book) return 'unavailable';
 					if (!canReachLightWorld() || !items.book) return 'unavailable';
-					var doorcheck = window.doorCheck(1,false,false,false,[(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'boots' : '','glove','firesource'],'boss');
+					var doorcheck = window.doorCheck(1,false,false,false,[(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'boots' : '','glove','firesource', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.DPBoss();
@@ -1082,7 +1083,7 @@
 				can_get_chest: function() {
 					//if (!items.book || !canReachLightWorldBunny()) return 'unavailable';
 					if (!canReachLightWorld() || !items.book) return 'unavailable';
-					var doorcheck = window.doorCheck(1,false,false,false,['boots','glove','firesource'],'item');
+					var doorcheck = window.doorCheck(1,false,false,false,['boots','glove','firesource', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.DPChests();
@@ -1109,14 +1110,14 @@
 				is_beaten: false,
 				is_beatable: function() {
 					if(!canReachPyramid()) return 'unavailable';
-					var doorcheck = window.doorCheck(3,false,true,true,['boots','hammer','bow'],'boss');
+					var doorcheck = window.doorCheck(3,false,true,true,['boots','hammer','bow', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.PoDBoss();
 				},
 				can_get_chest: function() {
 					if (!canReachPyramid()) return 'unavailable';
-					var doorcheck = window.doorCheck(3,false,true,true,['boots','hammer','bow'],'item');
+					var doorcheck = window.doorCheck(3,false,true,true,['boots','hammer','bow', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.PoDChests();
@@ -1126,14 +1127,14 @@
 				is_beaten: false,
 				is_beatable: function() {
 					if (!items.moonpearl || !canReachLightWorldBunny()) return 'unavailable';
-					var doorcheck = window.doorCheck(4,false,false,false,['flippers','mirror','hookshot','hammer'],'boss');
+					var doorcheck = window.doorCheck(4,false,false,false,['flippers','mirror','hookshot','hammer', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.SPBoss();
 				},
 				can_get_chest: function() {
 					if (!items.moonpearl || !canReachLightWorldBunny()) return 'unavailable';
-					var doorcheck = window.doorCheck(4,false,false,false,['flippers','mirror','hookshot','hammer'],'item');
+					var doorcheck = window.doorCheck(4,false,false,false,['flippers','mirror','hookshot','hammer', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.SPChests();
@@ -1142,13 +1143,13 @@
 				caption: 'Skull Woods',
 				is_beaten: false,
 				is_beatable: function() {
-					var doorcheck = window.doorCheck(5,false,false,false,['firerod','swordorswordless','mirrorskull'],'boss');
+					var doorcheck = window.doorCheck(5,false,false,false,['firerod','swordorswordless','mirrorskull', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.SWBoss();
 				},
 				can_get_chest: function() {
-					var doorcheck = window.doorCheck(5,false,false,false,['firerod','swordorswordless','mirrorskull'],'item');
+					var doorcheck = window.doorCheck(5,false,false,false,['firerod','swordorswordless','mirrorskull', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.SWChests();
@@ -1157,13 +1158,13 @@
 				caption: 'Thieves\' Town',
 				is_beaten: false,
 				is_beatable: function() {
-					var doorcheck = window.doorCheck(6,false,false,false,[(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'hammer' : '','glove'],'boss');
+					var doorcheck = window.doorCheck(6,false,false,false,[(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'hammer' : '','glove', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.TTBoss();
 				},
 				can_get_chest: function() {
-					var doorcheck = window.doorCheck(6,false,false,false,['hammer','glove'],'item');
+					var doorcheck = window.doorCheck(6,false,false,false,['hammer','glove', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.TTChests();
@@ -1173,14 +1174,14 @@
 				is_beaten: false,
 				is_beatable: function() {
 					if (!items.flippers) return 'unavailable';
-					var doorcheck = window.doorCheck(7,false,false,false,['freezor','hammer','glove','hookshot','somaria'],'boss');
+					var doorcheck = window.doorCheck(7,false,false,false,['freezor','hammer','glove','hookshot','somaria', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.IPBoss();
 				},
 				can_get_chest: function() {
 					if (!items.flippers) return 'unavailable';
-					var doorcheck = window.doorCheck(7,false,false,false,['freezor','hammer','glove','hookshot','somaria'],'item');
+					var doorcheck = window.doorCheck(7,false,false,false,['freezor','hammer','glove','hookshot','somaria', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.IPChests();
@@ -1190,7 +1191,7 @@
 				is_beaten: false,
 				is_beatable: function() {
 					if ((!activeFlute() && !(items.mirror && canReachLightWorldBunny())) || medallionCheck(0) === 'unavailable') return 'unavailable';
-					var doorcheck = window.doorCheck(8,false,true,false,['hookboots','hookshot','wizzrobe','firesource','somaria'],'boss');
+					var doorcheck = window.doorCheck(8,false,true,false,['hookboots','hookshot','wizzrobe','firesource','somaria', 'bomb'],'boss');
 					if(doorcheck)
 					{
 						if(doorcheck === 'unavailable')
@@ -1206,7 +1207,7 @@
 				},
 				can_get_chest: function() {
 					if ((!activeFlute() && !(items.mirror && canReachLightWorldBunny())) || medallionCheck(0) === 'unavailable') return 'unavailable';
-					var doorcheck = window.doorCheck(8,false,true,false,['hookboots','hookshot','wizzrobe','firesource','somaria'],'item');
+					var doorcheck = window.doorCheck(8,false,true,false,['hookboots','hookshot','wizzrobe','firesource','somaria', 'bomb'],'item');
 					if(doorcheck)
 					{
 						if(doorcheck === 'unavailable')
@@ -1227,7 +1228,7 @@
 					if(flags.doorshuffle != 'N')
 					{
 						if(medallionCheck(1) === 'unavailable' && (!items.mirror || ((!items.hookshot || !items.moonpearl) && items.glove < 2))) return 'unavailable';
-						var doorcheck = window.doorCheck(9,!items.flute && !items.lantern,true,false,['somaria','firerod',(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'laserbridge' : ''],'boss');
+						var doorcheck = window.doorCheck(9,!items.flute && !items.lantern,true,false,['somaria','firerod', 'bomb',(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'laserbridge' : ''],'boss');
 						if(doorcheck === 'unavailable')
 							return 'unavailable';
 						if(medallionCheck(1) === 'possible' && doorcheck === 'available')
@@ -1251,7 +1252,7 @@
 					if(flags.doorshuffle != 'N')
 					{
 						if(medallionCheck(1) === 'unavailable' && (!items.mirror || ((!items.hookshot || !items.moonpearl) && items.glove < 2))) return 'unavailable';
-						var doorcheck = window.doorCheck(9,!items.flute && !items.lantern,true,false,['somaria','firerod','laserbridge'],'item');
+						var doorcheck = window.doorCheck(9,!items.flute && !items.lantern,true,false,['somaria','firerod', 'bomb', 'laserbridge'],'item');
 						if(doorcheck === 'unavailable')
 							return 'unavailable';
 						if(medallionCheck(1) === 'possible' && doorcheck === 'available')
@@ -1277,7 +1278,7 @@
 				is_beatable: function() {
 					if ((crystalCheck() < flags.ganonvulncount && flags.goals != 'A') || ((crystalCheck() < flags.opentowercount || !items.agahnim2) && flags.goals != 'F') || !canReachLightWorld() || (flags.goals === 'A' && (!items.agahnim || !allDungeonCheck()))) return 'unavailable';
 					if ((flags.swordmode != 'S' && items.sword < 2) || (flags.swordmode === 'S' && !items.hammer) || (!items.lantern && !items.firerod)) return 'unavailable';
-					if (flags.goals === 'F' && (items.sword > 1 || flags.swordmode === 'S' && items.hammer) && (items.lantern || items.firerod)) return 'available';
+					if (flags.goals === 'F' && (items.sword > 1 || (flags.swordmode === 'S' && (items.hammer || items.net))) && (items.lantern || items.firerod) && items.bomb) return 'available';
 					return window.GTBoss();			
 				},
 				can_get_chest: function() {
@@ -1291,12 +1292,12 @@
 							return doorcheck;
 						if(doorcheck === 'darkpossible')
 						{
-							doorcheck = window.doorCheck(10,true,false,false,['hammer','firerod','hookshot','boomerang','somaria','wizzrobe','boots','bow',flags.bossshuffle === 'N' ? '' : 'icerod'],'item');
+							doorcheck = window.doorCheck(10,true,false,false,['hammer','firerod','hookshot','boomerang','somaria','wizzrobe','boots','bow', 'bomb', flags.bossshuffle === 'N' ? '' : 'icerod'],'item');
 							if(doorcheck === 'darkavailable')
 								return 'darkpossible';
 							return doorcheck;
 						}
-						return window.doorCheck(10,doorcheck.startsWith('dark'),false,false,['hammer','firerod','hookshot','boomerang','somaria','wizzrobe','boots','bow',flags.bossshuffle === 'N' ? '' : 'icerod'],'item');
+						return window.doorCheck(10,doorcheck.startsWith('dark'),false,false,['hammer','firerod','hookshot','boomerang','somaria','wizzrobe','boots','bow', 'bomb', flags.bossshuffle === 'N' ? '' : 'icerod'],'item');
 					}
 					return window.GTChests();
 				}
@@ -1384,12 +1385,14 @@
 				caption: 'Chicken House {bomb}',
 				is_opened: false,
 				is_available: function() {
-					return canReachLightWorld() ? 'available' : 'unavailable';
+					return canReachLightWorld() && items.bomb ? 'available' : 'unavailable';
 				}
 			}, { // [7]
 				caption: 'Bombable Hut {bomb}',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return items.bomb ? 'available' : 'unavailable';
+				}
 			}, { // [8]
 				caption: 'C House',
 				is_opened: false,
@@ -1398,7 +1401,7 @@
 				caption: 'Aginah\'s Cave {bomb}',
 				is_opened: false,
 				is_available: function() {
-					return canReachLightWorld() ? 'available' : 'unavailable';
+					return canReachLightWorld() && items.bomb ? 'available' : 'unavailable';
 				}
 			}, { // [10]
 				caption: 'Mire Shed (2)',
@@ -1418,7 +1421,7 @@
 				caption: 'Sahasrahla\'s Hut (3) {bomb}/{boots}',
 				is_opened: false,
 				is_available: function() {
-					return canReachLightWorldBunny() ? (items.moonpearl ? 'available' : 'unavailable') : 'unavailable';
+					return canReachLightWorldBunny() ? (items.moonpearl && (items.bomb || items.boots) ? 'available' : 'unavailable') : 'unavailable';
 				}
 			}, { // [13]
 				caption: 'Byrna Spike Cave',
@@ -1432,25 +1435,28 @@
 				caption: 'Kakariko Well (4 + {bomb})',
 				is_opened: false,
 				is_available: function() {
-					return canReachLightWorldBunny() ? (items.moonpearl ? 'available' : 'possible') : 'unavailable';
+					return canReachLightWorldBunny() ? (items.moonpearl ? (items.bomb ? 'available' : 'partialavailable') : 'possible') : 'unavailable';
 				}
 			}, { // [15]
 				caption: 'Thieve\'s Hut (4 + {bomb})',
 				is_opened: false,
 				is_available: function() {
-					return canReachLightWorldBunny() ? (items.moonpearl ? 'available' : (items.mirror ? 'possible' : 'unavailable')) : 'unavailable';
+					return canReachLightWorldBunny() ? (items.moonpearl ? (items.bomb ? 'available' : 'partialavailable') : items.mirror ? 'possible' : 'unavailable') : 'unavailable';
 				}
 			}, { // [16]
 				caption: 'Hype Cave! {bomb} (NPC + 4 {bomb})',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return items.bomb ? 'available' : 'unavailable';
+				}
 			}, { // [17]
 				caption: 'Paradox Cave (5 + 2 {bomb})',
 				is_opened: false,
 				is_available: function() {
 					return (activeFlute() || items.glove) && ((items.hookshot && items.moonpearl) || items.glove === 2) ?
-						(items.moonpearl ? (items.lantern || activeFlute() ? 'available' : 'darkavailable') : (items.sword >= 2 ? 'possible' : 'unavailable')) :
-						'unavailable';
+								(items.moonpearl && (items.bomb || items.bow || items.boomerang || items.firerod || items.icerod || items.somaria) ?
+								(items.lantern || activeFlute() ? (items.bomb ?
+								'available' : 'partialavailable') : 'darkavailable') : (items.sword >= 2 ? 'possible' : 'unavailable')) : 'unavailable';
 				}
 			}, { // [18]
 				caption: 'West of Sanctuary {boots}',
@@ -1462,13 +1468,13 @@
 				caption: 'Minimoldorm Cave (NPC + 4) {bomb}',
 				is_opened: false,
 				is_available: function() {
-					return canReachLightWorld() ? 'available' : 'unavailable';
+					return canReachLightWorld() && items.bomb ? 'available' : 'unavailable';
 				}
 			}, { // [20]
 				caption: 'Ice Rod Cave {bomb}',
 				is_opened: false,
 				is_available: function() {
-					return canReachLightWorld() ? 'available' : 'unavailable';
+					return canReachLightWorld() && items.bomb ? 'available' : 'unavailable';
 				}
 			}, { // [21]
 				caption: 'Hookshot Cave (bottom chest) {hookshot}/{boots}',
@@ -1597,10 +1603,10 @@
 					return canReachLightWorldBunny() ? (items.moonpearl ? 'available' : 'information') : 'unavailable';
 				}
 			}, { // [40]
-				caption: 'Graveyard Cliff Cave',
+				caption: 'Graveyard Cliff Cave {bomb}',
 				is_opened: false,
 				is_available: function() {
-					return canReachLightWorld() ? 'available' : 'unavailable';
+					return canReachLightWorld() && items.bomb ? 'available' : 'unavailable';
 				}
 			}, { // [41]
 				caption: 'Checkerboard Cave',
@@ -1648,7 +1654,7 @@
 				caption: 'Race Minigame {bomb}/{boots}',
 				is_opened: false,
 				is_available: function() {
-					return canReachLightWorldBunny() ? (items.moonpearl ? 'available' : 'possible') : 'unavailable';
+					return canReachLightWorldBunny() && (items.bomb || items.boots) ? (items.moonpearl ? 'available' : 'possible') : 'unavailable';
 				}
 			}, { // [48]
 				caption: 'Desert West Ledge {book}',
@@ -1715,7 +1721,7 @@
 					var doorcheck = window.doorCheck(11,false,false,true,['glove'],'item');
 					if(doorcheck)
 						return items.moonpearl ? doorcheck : 'unavailable';
-					return canReachLightWorldBunny() ? (items.glove && items.moonpearl ? 'available' : (items.mirror ? 'possible' : 'unavailable')) : 'unavailable';
+					return canReachLightWorldBunny() && (items.bomb || items.boots) ? (items.glove && items.moonpearl ? 'available' : (items.mirror ? 'possible' : 'unavailable')) : 'unavailable';
 				}
 			}, { // [56]
 				caption: "Castle Secret Entrance (Uncle + 1)",
@@ -1852,14 +1858,14 @@
 				is_beaten: false,
 				is_beatable: function() {
 					if (!items.book && !(items.flute && items.glove === 2 && items.mirror)) return 'unavailable';
-					var doorcheck = window.doorCheck(1,false,false,false,[(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'boots' : '','glove','firesource','mirrordesert'],'boss');
+					var doorcheck = window.doorCheck(1,false,false,false,[(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'boots' : '','glove','firesource','mirrordesert', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.DPBoss();
 				},
 				can_get_chest: function() {
 					if (!items.book && !(items.flute && items.glove === 2 && items.mirror)) return 'unavailable';
-					var doorcheck = window.doorCheck(1,false,false,false,['boots','glove','firesource','mirrordesert'],'item');
+					var doorcheck = window.doorCheck(1,false,false,false,['boots','glove','firesource','mirrordesert', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.DPChests();
@@ -1870,6 +1876,7 @@
 				is_beatable: function() {
 					if (!items.flute && !items.glove) return 'unavailable';
 					if (!items.mirror && !(items.hookshot && items.hammer)) return 'unavailable';
+					if (!canHitSwitch()) return 'unavailable';
 					var doorcheck = window.doorCheck(2,!items.flute && !items.lantern,false,false,[(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'firesource' : ''],'boss');
 					if(doorcheck)
 					{
@@ -1882,6 +1889,7 @@
 				can_get_chest: function() {
 					if (!items.flute && !items.glove) return 'unavailable';
 					if (!items.mirror && !(items.hookshot && items.hammer)) return 'unavailable';
+					if (!canHitSwitch()) return 'unavailable';
 					var doorcheck = window.doorCheck(2,!items.flute && !items.lantern,false,false,['firesource'],'item');
 					if(doorcheck)
 					{
@@ -1897,7 +1905,7 @@
 				is_beatable: function() {
 					if (!canReachDarkWorld()) return 'unavailable';
 					if (!items.agahnim && !(items.hammer && items.glove) && !(items.glove === 2 && items.flippers)) return 'unavailable';
-					var doorcheck = window.doorCheck(3,false,true,true,['boots','hammer','bow'],'boss');
+					var doorcheck = window.doorCheck(3,false,true,true,['boots','hammer','bow'],'boss', 'bomb');
 					if(doorcheck)
 						return doorcheck;
 					return window.PoDBoss();
@@ -1905,7 +1913,7 @@
 				can_get_chest: function() {
 					if (!canReachDarkWorld()) return 'unavailable';
 					if (!items.agahnim && !(items.hammer && items.glove) && !(items.glove === 2 && items.flippers)) return 'unavailable';
-					var doorcheck = window.doorCheck(3,false,true,true,['boots','hammer','bow'],'item');
+					var doorcheck = window.doorCheck(3,false,true,true,['boots','hammer','bow', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.PoDChests();
@@ -1917,7 +1925,7 @@
 					if (!canReachDarkWorld()) return 'unavailable';
 					if (!items.glove && !items.agahnim) return 'unavailable';
 					if (!can_reach_outcast() && (!items.agahnim || !items.moonpearl || !items.hammer)) return 'unavailable';
-					var doorcheck = window.doorCheck(4,false,false,false,['flippers','mirror','hookshot','hammer'],'boss');
+					var doorcheck = window.doorCheck(4,false,false,false,['flippers','mirror','hookshot','hammer', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.SPBoss();
@@ -1926,7 +1934,7 @@
 					if (!canReachDarkWorld()) return 'unavailable';
 					if (!items.glove && !items.agahnim) return 'unavailable';
 					if (!can_reach_outcast() && (!items.agahnim || !items.moonpearl || !items.hammer)) return 'unavailable';
-					var doorcheck = window.doorCheck(4,false,false,false,['flippers','mirror','hookshot','hammer'],'item');
+					var doorcheck = window.doorCheck(4,false,false,false,['flippers','mirror','hookshot','hammer', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.SPChests();
@@ -1936,14 +1944,14 @@
 				is_beaten: false,
 				is_beatable: function() {
 					if (!can_reach_outcast() || !canReachDarkWorld()) return 'unavailable';
-					var doorcheck = window.doorCheck(5,false,false,false,['firerod','swordorswordless'],'boss');
+					var doorcheck = window.doorCheck(5,false,false,false,['firerod','swordorswordless', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.SWBoss();
 				},
 				can_get_chest: function() {
 					if (!can_reach_outcast() || !canReachDarkWorld()) return 'unavailable';
-					var doorcheck = window.doorCheck(5,false,false,false,['firerod','swordorswordless'],'item');
+					var doorcheck = window.doorCheck(5,false,false,false,['firerod','swordorswordless', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.SWChests();
@@ -1953,14 +1961,14 @@
 				is_beaten: false,
 				is_beatable: function() {
 					if (!can_reach_outcast() || !canReachDarkWorld()) return 'unavailable';
-					var doorcheck = window.doorCheck(6,false,false,false,[(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'hammer' : '','glove'],'boss');
+					var doorcheck = window.doorCheck(6,false,false,false,[(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'hammer' : '','glove', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.TTBoss();
 				},
 				can_get_chest: function() {
 					if (!can_reach_outcast() || !canReachDarkWorld()) return 'unavailable';
-					var doorcheck = window.doorCheck(6,false,false,false,['hammer','glove'],'item');
+					var doorcheck = window.doorCheck(6,false,false,false,['hammer','glove', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.TTChests();
@@ -1970,14 +1978,14 @@
 				is_beaten: false,
 				is_beatable: function() {
 					if (!items.moonpearl || !items.flippers || items.glove !== 2 || !canReachDarkWorld()) return 'unavailable';
-					var doorcheck = window.doorCheck(7,false,false,false,['freezor','hammer','glove','hookshot','somaria'],'boss');
+					var doorcheck = window.doorCheck(7,false,false,false,['freezor','hammer','glove','hookshot','somaria', 'bomb'],'boss');
 					if(doorcheck)
 						return doorcheck;
 					return window.IPBoss();
 				},
 				can_get_chest: function() {
 					if (!items.moonpearl || !items.flippers || items.glove !== 2 || !canReachDarkWorld()) return 'unavailable';
-					var doorcheck = window.doorCheck(7,false,false,false,['freezor','hammer','glove','hookshot','somaria'],'item');
+					var doorcheck = window.doorCheck(7,false,false,false,['freezor','hammer','glove','hookshot','somaria', 'bomb'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.IPChests();
@@ -1992,7 +2000,7 @@
 					if (!items.moonpearl || !items.flute || items.glove !== 2 || !canReachDarkWorld() || medallionCheck(0) === 'unavailable') return 'unavailable';
 					//var state = medallionCheck(0);
 					//if (state) return state;
-					var doorcheck = window.doorCheck(8,false,true,false,['hookboots','hookshot','wizzrobe','firesource','somaria'],'boss');
+					var doorcheck = window.doorCheck(8,false,true,false,['hookboots','hookshot','wizzrobe','firesource','somaria', 'bomb'],'boss');
 					if(doorcheck)
 					{
 						if(doorcheck === 'unavailable')
@@ -2010,7 +2018,7 @@
 					if (!items.moonpearl || !items.flute || items.glove !== 2 || !canReachDarkWorld() || medallionCheck(0) === 'unavailable') return 'unavailable';
 					//var state = medallionCheck(0);
 					//if (state) return state;
-					var doorcheck = window.doorCheck(8,false,true,false,['hookboots','hookshot','wizzrobe','firesource','somaria'],'item');
+					var doorcheck = window.doorCheck(8,false,true,false,['hookboots','hookshot','wizzrobe','firesource','somaria', 'bomb'],'item');
 					if(doorcheck)
 					{
 						if(doorcheck === 'unavailable')
@@ -2032,7 +2040,7 @@
 					if (medallionCheck(1) === 'unavailable') return 'unavailable';
 					//var state = medallionCheck(1);
 					//if (state) return state;
-					var doorcheck = window.doorCheck(9,!items.flute && !items.lantern,true,false,['somaria','firerod',(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'laserbridge' : ''],'boss');
+					var doorcheck = window.doorCheck(9,!items.flute && !items.lantern,true,false,['somaria','firerod', 'bomb',(!flags.wildkeys && flags.gametype != 'R') || !flags.wildbigkeys ? 'laserbridge' : ''],'boss');
 					if(doorcheck)
 					{
 						if(doorcheck === 'unavailable')
@@ -2052,7 +2060,7 @@
 					if (medallionCheck(1) === 'unavailable') return 'unavailable';
 					//var state = medallionCheck(1);
 					//if (state) return state;				
-					var doorcheck = window.doorCheck(9,!items.flute && !items.lantern,true,false,['somaria','firerod','laserbridge'],'item');
+					var doorcheck = window.doorCheck(9,!items.flute && !items.lantern,true,false,['somaria','firerod', 'bomb', 'laserbridge'],'item');
 					if(doorcheck)
 					{
 						if(doorcheck === 'unavailable')
@@ -2072,7 +2080,7 @@
 					if ((crystalCheck() < flags.ganonvulncount && flags.goals != 'A') || ((crystalCheck() < flags.opentowercount || !items.agahnim2) && flags.goals != 'F') || !canReachDarkWorld() || (flags.goals === 'A' && (!items.agahnim || !allDungeonCheck()))) return 'unavailable';
 					if ((flags.swordmode != 'S' && items.sword < 2) || (flags.swordmode === 'S' && !items.hammer) || (!items.lantern && !items.firerod)) return 'unavailable';
 					//Fast Ganon
-					if (flags.goals === 'F' && (items.sword > 1 || flags.swordmode === 'S' && (items.hammer || items.net)) && (items.lantern || items.firerod)) return 'available';
+					if (flags.goals === 'F' && (items.sword > 1 || (flags.swordmode === 'S' && (items.hammer || items.net))) && (items.lantern || items.firerod) && items.bomb) return 'available';
 					return window.GTBoss();
 				},
 				can_get_chest: function() {
@@ -2081,7 +2089,7 @@
 						return (items.lantern || items.flute) ? 'possible' : 'darkpossible';
 					}
 					if (crystalCheck() < 7 && crystalCheck() < flags.opentowercount) return 'unavailable';
-					var doorcheck = window.doorCheck(10,!items.flute && !items.lantern,false,false,['hammer','firerod','hookshot','boomerang','somaria','wizzrobe','boots','bow',flags.bossshuffle === 'N' ? '' : 'icerod'],'item');
+					var doorcheck = window.doorCheck(10,!items.flute && !items.lantern,false,false,['hammer','firerod','hookshot','boomerang','somaria','wizzrobe','boots','bow', 'bomb',flags.bossshuffle === 'N' ? '' : 'icerod'],'item');
 					if(doorcheck)
 						return doorcheck;
 					return window.GTChests();
@@ -2170,10 +2178,10 @@
 						'unavailable';
 				}
 			}, { // [4]
-				caption: 'Mimic Cave ({mirror} outside of Turtle Rock)(Yellow = {medallion0} unkown OR possible w/out {firerod})',
+				caption: 'Mimic Cave ({bomb} {mirror} outside of Turtle Rock)(Yellow = {medallion0} unkown OR possible w/out {firerod})',
 				is_opened: false,
 				is_available: function() {
-					if (!items.moonpearl || !items.hammer || items.glove !== 2 || (!items.somaria && flags.doorshuffle === 'N') || !items.mirror) return 'unavailable';
+					if (!items.moonpearl || !items.hammer || items.glove !== 2 || (!items.somaria && flags.doorshuffle === 'N') || !items.mirror || !items.bomb) return 'unavailable';
 					var state = medallionCheck(1);	
 					if (state) return state === 'possible' && !items.flute && !items.lantern ? 'darkpossible' : state;
 
@@ -2199,7 +2207,7 @@
 				caption: 'Bombable Hut {bomb}',
 				is_opened: false,
 				is_available: function() {
-					return can_reach_outcast() ? 'available' : 'unavailable';
+					return can_reach_outcast() && items.bomb ? 'available' : 'unavailable';
 				}
 			}, { // [8]
 				caption: 'C House',
@@ -2210,7 +2218,9 @@
 			}, { // [9]
 				caption: 'Aginah\'s Cave {bomb}',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return (items.bomb ? 'available' : 'unavailable');
+				}
 			}, { // [10]
 				caption: 'Mire Shed (2)',
 				is_opened: false,
@@ -2228,7 +2238,9 @@
 			}, { // [12]
 				caption: 'Sahasrahla\'s Hut (3) {bomb}/{boots}',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return (items.bomb || items.boots ? 'available' : 'unavailable');
+				}
 			}, { // [13]
 				caption: 'Byrna Spike Cave',
 				is_opened: false,
@@ -2240,24 +2252,28 @@
 			}, { // [14]
 				caption: 'Kakariko Well (4 + {bomb})',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return items.bomb ? 'available' : 'partialavailable';
+				}
 			}, { // [15]
 				caption: 'Thieve\'s Hut (4 + {bomb})',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return items.bomb ? 'available' : 'partialavailable';
+				}
 			}, { // [16]
 				caption: 'Hype Cave! {bomb} (NPC + 4 {bomb})',
 				is_opened: false,
 				is_available: function() {
-					return can_reach_outcast() || (items.agahnim && items.moonpearl && items.hammer) ? 'available' : 'unavailable';
+					return items.bomb && (can_reach_outcast() || (items.agahnim && items.moonpearl && items.hammer)) ? 'available' : 'unavailable';
 				}
 			}, { // [17]
 				caption: 'Paradox Cave (5 + 2 {bomb})',
 				is_opened: false,
 				is_available: function() {
-					return (items.glove || items.flute) && (items.hookshot || items.mirror && items.hammer) ?
-						items.lantern || items.flute ? 'available' : 'darkavailable' :
-						'unavailable';
+					return (items.glove || items.flute) && (items.hookshot || items.mirror && items.hammer) &&
+						(items.bomb || items.bow || items.boomerang || items.firerod || items.icerod || items.somaria) ?
+						(items.lantern || items.flute ? (items.bomb ? 'available' : 'partialavailable') : 'darkavailable') : 'unavailable';
 				}
 			}, { // [18]
 				caption: 'West of Sanctuary {boots}',
@@ -2268,11 +2284,15 @@
 			}, { // [19]
 				caption: 'Minimoldorm Cave (NPC + 4) {bomb}',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return (items.bomb ? 'available' : 'unavailable');
+				}
 			}, { // [20]
 				caption: 'Ice Rod Cave {bomb}',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return (items.bomb ? 'available' : 'unavailable');
+				}
 			}, { // [21]
 				caption: 'Hookshot Cave (bottom chest) {hookshot}/{boots}',
 				is_opened: false,
@@ -2403,10 +2423,10 @@
 					return items.mirror && (can_reach_outcast() || items.agahnim && items.moonpearl && items.hammer) ? 'available' : 'unavailable';
 				}
 			}, { // [40]
-				caption: 'Graveyard Cliff Cave {mirror}',
+				caption: 'Graveyard Cliff Cave {mirror} {bomb}',
 				is_opened: false,
 				is_available: function() {
-					return can_reach_outcast() && items.mirror ? 'available' : 'unavailable';
+					return can_reach_outcast() && items.mirror && items.bomb ? 'available' : 'unavailable';
 				}
 			}, { // [41]
 				caption: 'Checkerboard Cave {mirror}',
@@ -2445,7 +2465,7 @@
 				is_opened: false,
 				is_available: function() {
 					return (items.glove || items.flute) && (items.hookshot || items.hammer && items.mirror) ?
-						items.mirror && items.moonpearl && items.glove === 2 ?
+						items.bomb && items.mirror && items.moonpearl && items.glove === 2 ?
 							items.lantern || items.flute ? 'available' : 'darkavailable' :
 							'information' :
 						'unavailable';
@@ -2453,7 +2473,9 @@
 			}, { // [47]
 				caption: 'Race Minigame {bomb}/{boots}',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return (items.bomb || items.boots) || can_reach_outcast() || (items.agahnim && items.moonpearl && items.hammer) ? 'available' : 'unavailable';
+				}
 			}, { // [48]
 				caption: 'Desert West Ledge {book}/{mirror}',
 				is_opened: false,
@@ -2509,7 +2531,7 @@
 					return 'unavailable';
 				}
 			}, { // [54]
-				caption: 'Buried Itam {shovel}',
+				caption: 'Buried Item {shovel}',
 				is_opened: false,
 				is_available: function() {
 					return items.shovel ? 'available' : 'unavailable';
@@ -2518,17 +2540,21 @@
 				caption: 'Escape Sewer Side Room (3) {bomb}/{boots}' + (flags.gametype === 'S' ? '' : ' (may need small key)'),
 				is_opened: false,
 				is_available: function() {
+					if (!items.boots && !items.bomb) return 'unavailable';
+
 					var doorcheck = window.doorCheck(11,false,false,flags.gametype != 'S',['glove'],'item');
 					if(doorcheck)
 						return doorcheck;
 					if (flags.gametype === 'S') return 'available';
 					if (flags.wildkeys || flags.gametype == 'R') {
 						if (items.glove) return 'available';
-						if (items.smallkeyhalf0 === 1 || flags.gametype == 'R') return (items.lantern || items.firerod) ? 'available' : 'darkavailable';
+						if (items.bomb || melee_bow() || rod() || cane()) {
+							if (items.smallkeyhalf0 === 1 || flags.gametype == 'R') return (items.lantern || items.firerod ? 'available' : 'darkavailable');
+						}
 						return 'unavailable';
 					}
 					
-					return items.glove ? 'available' : (items.lantern || items.firerod) ? 'possible' : 'darkpossible';
+					return (items.glove ? 'available' : (items.bomb || melee_bow() || rod() || cane()) ? (items.lantern || items.firerod ? 'possible' : 'darkpossible') : 'unavailable');
 				}
 			}, { // [56]
 				caption: "Castle Secret Entrance (Uncle + 1)",
@@ -2541,7 +2567,7 @@
 					var doorcheck = window.doorCheck(11,false,false,flags.gametype != 'S',['glove'],'item');
 					if(doorcheck)
 						return doorcheck;
-					return 'available';
+					return items.bomb || melee_bow() || items.firerod || items.somaria || items.byrna ? 'available' : 'partialavailable'
 				}
 			}, { // [58]
 				caption: 'Sanctuary',

--- a/js/chests.js
+++ b/js/chests.js
@@ -2202,7 +2202,9 @@
 			}, { // [6]
 				caption: 'Chicken House {bomb}',
 				is_opened: false,
-				is_available: always
+				is_available: function() {
+					return items.bomb ? 'available' : 'unavailable';
+				}
 			}, { // [7]
 				caption: 'Bombable Hut {bomb}',
 				is_opened: false,

--- a/js/dungeons.js
+++ b/js/dungeons.js
@@ -401,6 +401,7 @@
 	};
 
     window.TTBoss = function() {
+		if (flags.bossshuffle === 'N' && !items.bomb) return 'unavailable';
 		var dungeoncheck = enemizer_check(6);
 		return (items.bigkey6 ? dungeoncheck : 'unavailable');
     };
@@ -423,7 +424,7 @@
 		if (!items.boots && !items.hookshot) return 'unavailable';
 		if (medallion_check(0) === 'unavailable') return 'unavailable';
 		var dungeoncheck = enemizer_check(8);
-		if (!items.bigkey8 || !items.somaria || dungeoncheck === 'unavailable') return 'unavailable';
+		if (!items.bigkey8 || !items.somaria || !items.bomb || dungeoncheck === 'unavailable') return 'unavailable';
 		if (dungeoncheck === 'possible' || medallion_check(0) === 'possible') {
 			return (items.lantern ? 'possible' : 'darkpossible');
 		}
@@ -442,7 +443,7 @@
     window.TRFrontBoss = function() {
 		if (medallion_check(1) === 'unavailable') return 'unavailable';
 		var dungeoncheck = enemizer_check(9);
-		if (!items.bigkey9 || !items.somaria || dungeoncheck === 'unavailable') return 'unavailable';
+		if (!items.bigkey9 || !items.somaria || (!items.bomb && !items.boots) || dungeoncheck === 'unavailable') return 'unavailable';
 		if (flags.wildkeys) {
 			if (items.smallkey9 < 4 && flags.gametype != 'R') return 'unavailable';
 		}
@@ -451,7 +452,7 @@
 
 	window.TRMidBoss = function() {
 		var dungeoncheck = enemizer_check(9);
-		if (!items.bigkey9 || !items.somaria || dungeoncheck === 'unavailable') return 'unavailable';
+		if (!items.bigkey9 || !items.somaria || (!items.bomb && !items.boots) || dungeoncheck === 'unavailable') return 'unavailable';
 		if (flags.wildbigkeys || flags.wildkeys) {
 			if (items.smallkey9 < 2 && flags.gametype != 'R') return 'unavailable';
 			if ((items.smallkey9 < 4 && flags.gametype != 'R') || medallion_check(1) === 'possible') return 'possible';
@@ -478,7 +479,7 @@
     window.GTBoss = function() {
 		var dungeoncheck = enemizer_check(0);
 		
-		if (!items.bigkey10 || (items.bow === 0 && flags.enemyshuffle === 'N') || (!items.lantern && !items.firerod) || !items.hookshot || ((items.sword < 2 && flags.swordmode != 'S') || (flags.swordmode === 'S' && !items.hammer)) || dungeoncheck === 'unavailable') return 'unavailable';
+		if (!items.bigkey10 || (items.bow === 0 && flags.enemyshuffle === 'N') || (!items.lantern && !items.firerod) || !items.hookshot || ((items.sword < 2 && flags.swordmode != 'S') || (flags.swordmode === 'S' && !items.hammer)) || !items.bomb || dungeoncheck === 'unavailable') return 'unavailable';
 		if (flags.wildkeys) {
 			if (items.smallkey10 === 0 && flags.gametype != 'R') return 'unavailable';
 			if (items.smallkey10 < 3 && flags.gametype != 'R') return 'possible';
@@ -707,38 +708,8 @@
 		
 		//1) No Key Shuffle
 		if (!flags.wildbigkeys && !flags.wildkeys && flags.gametype != 'R') {
-			if (items.bow === 0 && flags.enemyshuffle === 'N') {
-				//Shooter Room
-				chests[0] = 'P';
-				//Map Chest
-				chests[1] = 'P';
-				//The Arena - Ledge
-				chests[2] = 'P';
-				//Stalfos Basement
-				chests[3] = 'P';
-				//The Arena - Bridge
-				chests[4] = 'P';
-				//Big Key Chest
-				chests[5] = 'P';
-				//Compass Chest
-				chests[6] = 'P';
-				//Harmless Hellway
-				chests[7] = 'P';
-				//Dark Basement - Left
-				chests[8] = (items.lantern || items.firerod) ? 'P' : 'DP';
-				//Dark Basement - Right
-				chests[9] = (items.lantern || items.firerod) ? 'P' : 'DP';
-				//Dark Maze - Top
-				chests[10] = (items.lantern ? 'P' : 'DP');
-				//Dark Maze - Bottom
-				chests[11] = (items.lantern ? 'P' : 'DP');
-				//Big Chest
-				chests[12] = (items.lantern ? 'P' : 'DP');
-				//Boss
-				chests[13] = 'U';
-				
-			} else {
-				//If there is a bow, all chests are available with hammer, with dark logic
+			if ((items.bow > 0 || flags.enemyshuffle != 'N') && items.bomb) {
+				//If there is a bow and bombs, all chests are available with hammer, with dark logic
 				//Reserving four keys up front, two in the back, with the big key
 				
 				//Shooter Room
@@ -769,96 +740,21 @@
 				chests[12] = (items.lantern ? 'A' : 'DA');
 				//Boss
 				chests[13] = ConvertBossToChest(PoDBoss());
-			}
-		//2) Retro (w/ Big Key shuffle checks)
-		//We ignore the wild keys check, as retro overrides it
-		} else if (flags.gametype === 'R') {
-			chests[0] = 'A';
-			
-			if (items.bow > 0 || flags.enemyshuffle != 'N') {
-				//Map Chest
-				chests[1] = 'A';
-				//The Arena - Ledge
-				chests[2] = 'A';
-			}
-			
-			chests[3] = 'A';
-			chests[4] = 'A';
-			chests[5] = 'A';
-			chests[6] = 'A';
-			chests[7] = 'A';
-			chests[8] = (items.lantern || items.firerod) ? 'A' : 'DA';
-			chests[9] = (items.lantern || items.firerod) ? 'A' : 'DA';
-			chests[10] = (items.lantern ? 'A' : 'DA');
-			chests[11] = (items.lantern ? 'A' : 'DA');
-			//Big Chest
-			if (items.bigkey3) {
-				chests[12] = (items.lantern ? 'A' : 'DA');
-			}			
-		
-		//3) Small Key shuffle only
-		} else if (!flags.wildbigkeys && flags.wildkeys) {
-			chests[0] = 'A';
-
-			if (items.bow > 0 || flags.enemyshuffle != 'N') {
-				//Map Chest
-				chests[1] = 'A';
-				//The Arena - Ledge
-				chests[2] = 'A';
-			}
-			
-			if ((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) || items.smallkey3 > 0) {
-				//Stalfos Basement
-				chests[3] = 'A';
-				//The Arena - Bridge
-				chests[4] = 'A';
-			}
-			
-			//Big Key Chest
-			if (((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) && items.smallkey3 > 2) || items.smallkey3 > 3) {
-				chests[5] = 'A';
-			}
-			
-			if (((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) && items.smallkey3 > 0) || items.smallkey3 > 1) {
-				//Compass Chest
-				chests[6] = 'A';
-				//Dark Basement - Left
-				chests[8] = (items.lantern || items.firerod) ? 'A' : 'DA';
-				//Dark Basement - Right
-				chests[9] = (items.lantern || items.firerod) ? 'A' : 'DA';
-			}
-			
-			if (((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) && items.smallkey3 > 3) || items.smallkey3 > 4) {
-				//Harmless Hellway
-				chests[7] = 'A';
-			}
-			
-			if (((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) && items.smallkey3 > 1) || items.smallkey3 > 2) {
-				//Dark Maze - Top
-				chests[10] = (items.lantern ? 'A' : 'DA');
-				//Dark Maze - Bottom
-				chests[11] = (items.lantern ? 'A' : 'DA');
-				//Big Chest
-				chests[12] = (items.lantern ? 'K' : 'DP'); // This is the big key replacement
-			}
-			
-			//Boss
-			chests[13] = ConvertBossToChest(PoDBoss());
-		//4) Big Key shuffle only
-		} else if (flags.wildbigkeys && !flags.wildkeys) {
-			if (items.bow === 0 && flags.enemyshuffle === 'N') {
+			} else {
 				//Shooter Room
 				chests[0] = 'P';
-				//Map Chest
-				chests[1] = 'P';
-				//The Arena - Ledge
-				chests[2] = 'P';
+				if (items.bow > 0 || flags.enemyshuffle != 'N') {
+					//Map Chest
+					chests[1] = (items.bomb || items.boots) ? 'P' : 'U';
+					//The Arena - Ledge
+					chests[2] = (items.bomb ? 'P' : 'U');
+				}
 				//Stalfos Basement
 				chests[3] = 'P';
 				//The Arena - Bridge
 				chests[4] = 'P';
 				//Big Key Chest
-				chests[5] = 'P';
+				chests[5] = (items.bomb ? 'P' : 'U');
 				//Compass Chest
 				chests[6] = 'P';
 				//Harmless Hellway
@@ -872,12 +768,97 @@
 				//Dark Maze - Bottom
 				chests[11] = (items.lantern ? 'P' : 'DP');
 				//Big Chest
-				chests[12] = (items.bigkey3 ? (items.lantern ? 'P' : 'DP') : 'U');
+				chests[12] = (items.bomb ? items.lantern ? 'P' : 'DP' : 'U');
 				//Boss
-				chests[13] = 'U';
-				
-			} else {
-				//If there is a bow, all chests are available with hammer, with dark logic
+				chests[13] = 'U';				
+			}
+
+		//2) Retro (w/ Big Key shuffle checks)
+		//We ignore the wild keys check, as retro overrides it
+		} else if (flags.gametype === 'R') {
+			chests[0] = 'A';
+			
+			if (items.bow > 0 || flags.enemyshuffle != 'N') {
+				//Map Chest
+				chests[1] = (items.bomb || items.boots) ? 'A' : 'U';
+				//The Arena - Ledge
+				chests[2] = (items.bomb ? 'A' : 'U');
+			}
+			//Stalfos Basement
+			chests[3] = 'A';
+			//The Arena - Bridge
+			chests[4] = 'A';
+			//Big Key Chest
+			chests[5] = (items.bomb ? 'A' : 'U');
+			//Compass Chest
+			chests[6] = 'A';
+			//Harmless Hellway
+			chests[7] = 'A';
+			//Dark Basement - Left
+			chests[8] = (items.lantern || items.firerod) ? 'A' : 'DA';
+			//Dark Basement - Right
+			chests[9] = (items.lantern || items.firerod) ? 'A' : 'DA';
+			//Dark Maze - Top
+			chests[10] = (items.lantern ? 'A' : 'DA');
+			//Dark Maze - Bottom
+			chests[11] = (items.lantern ? 'A' : 'DA');
+			//Big Chest
+			if (items.bigkey3) {
+				chests[12] = (items.bomb ? items.lantern ? 'A' : 'DA' : 'P');
+			}			
+		
+		//3) Small Key shuffle only
+		} else if (!flags.wildbigkeys && flags.wildkeys) {
+			chests[0] = 'A';
+
+			if (items.bow > 0 || flags.enemyshuffle != 'N') {
+				//Map Chest
+				chests[1] = (items.bomb || items.boots) ? 'A' : 'U';
+				//The Arena - Ledge
+				chests[2] = (items.bomb ? 'A' : 'U');
+			}
+			
+			if ((items.hammer && ((items.bow > 0 || flags.enemyshuffle != 'N') && (items.bomb || items.boots))) || items.smallkey3 > 0) {
+				//Stalfos Basement
+				chests[3] = 'A';
+				//The Arena - Bridge
+				chests[4] = 'A';
+			}
+			
+			//Big Key Chest
+			if (items.bomb && (((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) && items.smallkey3 > 2) || items.smallkey3 > 3)) {
+				chests[5] = 'A';
+			}
+			
+			if (((items.hammer && ((items.bow > 0 || flags.enemyshuffle != 'N') && (items.bomb || items.boots))) && items.smallkey3 > 0) || items.smallkey3 > 1) {
+				//Compass Chest
+				chests[6] = 'A';
+				//Dark Basement - Left
+				chests[8] = (items.lantern || items.firerod) ? 'A' : 'DA';
+				//Dark Basement - Right
+				chests[9] = (items.lantern || items.firerod) ? 'A' : 'DA';
+			}
+			
+			if (((items.hammer && ((items.bow > 0 || flags.enemyshuffle != 'N') && (items.bomb || items.boots))) && items.smallkey3 > 3) || items.smallkey3 > 4) {
+				//Harmless Hellway
+				chests[7] = 'A';
+			}
+			
+			if (((items.hammer && ((items.bow > 0 || flags.enemyshuffle != 'N') && (items.bomb || items.boots))) && items.smallkey3 > 1) || items.smallkey3 > 2) {
+				//Dark Maze - Top
+				chests[10] = (items.lantern ? 'A' : 'DA');
+				//Dark Maze - Bottom
+				chests[11] = (items.lantern ? 'A' : 'DA');
+				//Big Chest
+				chests[12] = (items.bomb ? items.lantern ? 'K' : 'DP' : 'P'); // This is the big key replacement
+			}
+			
+			//Boss
+			chests[13] = ConvertBossToChest(PoDBoss());
+		//4) Big Key shuffle only
+		} else if (flags.wildbigkeys && !flags.wildkeys) {
+			if ((items.bow > 0 || flags.enemyshuffle === 'N') && items.bomb) {
+				//If there is a bow and bombs, all chests are available with hammer, with dark logic
 				//Reserving four keys up front, two in the back, with the big key
 				
 				//Shooter Room
@@ -908,6 +889,37 @@
 				chests[12] = (items.bigkey3 ? (items.lantern ? 'A' : 'DA') : 'U');
 				//Boss
 				chests[13] = ConvertBossToChest(PoDBoss());
+			} else {
+				//Shooter Room
+				chests[0] = 'P';
+				if (items.bow > 0 || flags.enemyshuffle === 'N') {
+					//Map Chest
+					chests[1] = (items.bomb || items.boots) ? 'P' : 'U';
+					//The Arena - Ledge
+					chests[2] = items.bomb ? 'P' : 'U';
+				}
+				//Stalfos Basement
+				chests[3] = 'P';
+				//The Arena - Bridge
+				chests[4] = 'P';
+				//Big Key Chest
+				chests[5] = (items.bomb ? 'P' : 'U');
+				//Compass Chest
+				chests[6] = 'P';
+				//Harmless Hellway
+				chests[7] = 'P';
+				//Dark Basement - Left
+				chests[8] = (items.lantern || items.firerod) ? 'P' : 'DP';
+				//Dark Basement - Right
+				chests[9] = (items.lantern || items.firerod) ? 'P' : 'DP';
+				//Dark Maze - Top
+				chests[10] = (items.lantern ? 'P' : 'DP');
+				//Dark Maze - Bottom
+				chests[11] = (items.lantern ? 'P' : 'DP');
+				//Big Chest
+				chests[12] = (items.bigkey3 && items.bomb ? (items.lantern ? 'P' : 'DP') : 'U');
+				//Boss
+				chests[13] = 'U';
 			}
 		//5) Small Key + Big Key shuffle
 		} else {
@@ -915,12 +927,12 @@
 			
 			if (items.bow > 0 || flags.enemyshuffle != 'N') {
 				//Map Chest
-				chests[1] = 'A';
+				chests[1] = (items.bomb || items.boots ? 'A' : 'U');
 				//The Arena - Ledge
-				chests[2] = 'A';
+				chests[2] = (items.bomb ? 'A' : 'U');
 			}
 			
-			if ((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) || items.smallkey3 > 0) {
+			if ((items.hammer && ((items.bow > 0 || flags.enemyshuffle != 'N') && (items.bomb || items.boots))) || items.smallkey3 > 0) {
 				//Stalfos Basement
 				chests[3] = 'A';
 				//The Arena - Bridge
@@ -928,11 +940,11 @@
 			}
 			
 			//Big Key Chest
-			if (((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) && items.smallkey3 > 2) || items.smallkey3 > 3) {
+			if (items.bomb && (((items.hammer && ((items.bow > 0 || flags.enemyshuffle != 'N'))) && items.smallkey3 > 2) || items.smallkey3 > 3)) {
 				chests[5] = 'A';
 			}
 			
-			if (((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) && items.smallkey3 > 0) || items.smallkey3 > 1) {
+			if (((items.hammer && ((items.bow > 0 || flags.enemyshuffle != 'N') && (items.bomb || items.boots))) && items.smallkey3 > 0) || items.smallkey3 > 1) {
 				//Compass Chest
 				chests[6] = 'A';
 				//Dark Basement - Left
@@ -941,18 +953,18 @@
 				chests[9] = (items.lantern || items.firerod) ? 'A' : 'DA';
 			}
 			
-			if (((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) && items.smallkey3 > 3) || items.smallkey3 > 4) {
-				//Harmless Hellway
+			//Harmless Hellway
+			if (((items.hammer && ((items.bow > 0 || flags.enemyshuffle != 'N') && (items.bomb || items.boots))) && items.smallkey3 > 3) || items.smallkey3 > 4) {
 				chests[7] = 'A';
 			}
 			
-			if (((items.hammer && (items.bow > 0 || flags.enemyshuffle != 'N')) && items.smallkey3 > 1) || items.smallkey3 > 2) {
+			if (((items.hammer && ((items.bow > 0 || flags.enemyshuffle != 'N') && (items.bomb || items.boots))) && items.smallkey3 > 1) || items.smallkey3 > 2) {
 				//Dark Maze - Top
 				chests[10] = (items.lantern ? 'A' : 'DA');
 				//Dark Maze - Bottom
 				chests[11] = (items.lantern ? 'A' : 'DA');
 				//Big Chest
-				chests[12] = (items.bigkey3 ? (items.lantern ? 'A' : 'DA') : 'U');
+				chests[12] = (items.bigkey3 && items.bomb ? (items.lantern ? 'A' : 'DA') : 'U');
 			}
 			
 			//Boss
@@ -973,10 +985,9 @@
 			chests[0] = 'K';
 		}
 		
-		if (items.smallkey4 > 0 || flags.gametype == 'R')
-		{
+		if (!flags.wildkeys || items.smallkey4 > 0 || flags.gametype == 'R') {
 			//Map Chest
-			chests[1] = 'A';
+			chests[1] = (items.bomb ? 'A' : 'U');
 			
 			//Without hammer, cannot go any further
 			if (items.hammer) {
@@ -984,12 +995,10 @@
 				chests[2] = 'A';
 
 				//Big Chest
-				if (items.bigkey4) {
-					if (flags.wildbigkeys) {
-						chests[3] = 'A';
-					} else {
-						chests[3] = (items.hookshot ? 'K' : 'U');
-					}
+				if (flags.wildbigkeys) {
+					chests[3] = (items.bigkey4 ? 'A' : 'U');
+				} else {
+					chests[3] = (items.hookshot ? 'K' : 'U');
 				}
 
 				//West Chest
@@ -1049,13 +1058,15 @@
 		chests[3] = 'A';
 		
 		//Big Chest
-		if (flags.wildbigkeys) {
-			chests[4] = (items.bigkey5) ? 'A' : 'U';
-		} else {
-			if (items.firerod && (items.sword > 0 || flags.swordmode === 'S') && dungeoncheck === 'available') {
-				chests[4] = 'K'; //If is full clearable, set to a key, else possible
+		if (items.bomb) {
+			if (flags.wildbigkeys) {
+				chests[4] = (items.bigkey5) ? 'A' : 'U';
 			} else {
-				chests[4] = 'P';
+				if (items.firerod && (items.sword > 0 || flags.swordmode === 'S') && dungeoncheck === 'available') {
+					chests[4] = 'K'; //If is full clearable, set to a key, else possible
+				} else {
+					chests[4] = 'P';
+				}
 			}
 		}
 		
@@ -1115,7 +1126,11 @@
 			}
 			
 			//Boss
-			chests[7] = ConvertBossToChest(TTBoss());
+			if (enemizer[6] === 6 && !item.bomb) {
+				chests[7] = 'U';
+			} else {
+				chests[7] = ConvertBossToChest(TTBoss());
+			}
 		}
 		
 		return available_chests(6, chests, items.maxchest6, items.chest6);
@@ -1129,48 +1144,50 @@
 		if (flags.wildkeys || flags.gametype === 'R') {
 			chests[0] = 'A';
 		} else {
-			chests[0] = 'K'; //Reserving as small key 1
+			chests[0] = items.bomb ? 'K' : 'P'; //Reserving as small key 1 but only if we can get further into the dungeon as well
 		}
 		
-        //Spike Room
-		if (flags.wildkeys) {
-			chests[1] = (items.hookshot || (items.smallkey7 > 0 || flags.gametype == 'R')) ? 'A' : 'U';			
-		} else {
-			chests[1] = (items.hookshot || items.somaria) ? 'A' : 'P';
-		}
-		
-		if (items.hammer) {
-			//Map Chest
-			if (items.glove > 0) {
-				if (flags.wildkeys) {
-					chests[2] = (items.hookshot || (items.smallkey7 > 0 || flags.gametype == 'R')) ? 'A' : 'U';			
-				} else {
-					chests[2] = (items.hookshot || items.somaria) ? (!flags.wildkeys ? 'K' : 'A') : 'P'; //Reserving as small key 2
-				}
-		
-				//Big Key Chest
-				if (flags.wildkeys) {
-					chests[3] = (items.hookshot || (items.smallkey7 > 0 || flags.gametype == 'R')) ? 'A' : 'U';
-				} else {
-					chests[3] = (items.hookshot || items.somaria) ? 'A' : 'P';
-				}
+		if (items.bomb) {
+			//Spike Room
+			if (flags.wildkeys) {
+				chests[1] = (items.hookshot || (items.smallkey7 > 0 || flags.gametype == 'R')) ? 'A' : 'U';			
+			} else {
+				chests[1] = items.hookshot ? 'A' : 'P';
 			}
+			
+			if (items.hammer) {
+				//Map Chest
+				if (items.glove > 0) {
+					if (flags.wildkeys) {
+						chests[2] = (items.hookshot || (items.smallkey7 > 0 || flags.gametype == 'R')) ? 'A' : 'U';		
+					} else {
+						chests[2] = (items.hookshot ? (!flags.wildkeys ? 'K' : 'A') : 'P'); //Reserving as small key 2
+					}
 
-			//Boss
-			chests[7] = ConvertBossToChest(IPBoss());
-		}
-		
-        //Freezor Chest
-		chests[4] = 'A';
-		
-        //Iced T Room
-		chests[5] = 'A';
-		
-        //Big Chest
-		if (flags.wildbigkeys) {
-			chests[6] = (items.bigkey7 ? 'A' : 'U');
-		} else {
-			chests[6] = (items.hammer ? 'K' : 'P');
+					//Big Key Chest
+					if (flags.wildkeys) {
+						chests[3] = (items.hookshot || (items.smallkey7 > 0 || flags.gametype == 'R')) ? 'A' : 'U';
+					} else {
+						chests[3] = (items.hookshot || items.somaria) ? 'A' : 'P';
+					}
+				}
+
+				//Boss
+				chests[7] = ConvertBossToChest(IPBoss());
+			}
+			
+			//Freezor Chest
+			chests[4] = 'A';
+			
+			//Iced T Room
+			chests[5] = 'A';
+			
+			//Big Chest
+			if (flags.wildbigkeys) {
+				chests[6] = (items.bigkey7 ? 'A' : 'U');
+			} else {
+				chests[6] = (items.hammer ? 'K' : 'P');
+			}
 		}
 		
 		return available_chests(7, chests, items.maxchest7, items.chest7);
@@ -1217,7 +1234,7 @@
 		}		
 		
 		//Boss
-		chests[7] = ConvertBossToChest(MMBoss());
+		chests[7] = (items.bomb ? ConvertBossToChest(MMBoss()) : 'U');
 		
 		return available_chests(8, chests, items.maxchest8, items.chest8);
     };
@@ -1260,19 +1277,22 @@
 			chests[4] = 'K'; //Reserved as third small key, regardless if the fire rod is accessable or not
 			
 			//Big Chest
-			chests[5] = (items.firerod ? 'K' : 'P'); //Reserved as big key, if fire rod made it accessable to this point
+			chests[5] = (items.bomb ? items.firerod ? 'K' : 'P' : 'U'); //Reserved as big key, if fire rod made it accessable to this point
 			
-			//Crystaroller Room
-			chests[6] = (items.firerod ? 'K' : 'P'); //Reserved as fourth small key
-			
-			//Laser Bridge
-			chests[7] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-			chests[8] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-			chests[9] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-			chests[10] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-			
-			//Boss
-			chests[11] = ConvertBossToChest(TRFrontBoss());
+			if (items.bomb || items.boots) {
+				//Crystaroller Room
+				chests[6] = (items.firerod ? 'K' : 'P'); //Reserved as fourth small key
+
+				//Laser Bridge
+				chests[7] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+				chests[8] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+				chests[9] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+				chests[10] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+
+				//Boss
+				chests[11] = ConvertBossToChest(TRFrontBoss());
+			}
+
 		//2) Retro (w/ Big Key shuffle checks)
 		//We ignore the wild keys check, as retro overrides it
 		} else if (flags.gametype === 'R') {
@@ -1294,19 +1314,22 @@
 			chests[4] = 'A';
 			
 			//Big Chest
-			chests[5] = (items.firerod ? 'K' : 'P'); //Reserved as big key, if fire rod made it accessable to this point
+			chests[5] = (items.bomb ? items.firerod ? 'K' : 'P' : 'U'); //Reserved as big key, if fire rod made it accessable to this point
 			
-			//Crystaroller Room
-			chests[6] = (items.firerod ? 'A' : 'P');
-			
-			//Laser Bridge
-			chests[7] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-			chests[8] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-			chests[9] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-			chests[10] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-			
-			//Boss
-			chests[11] = ConvertBossToChest(TRFrontBoss());
+			if (items.bomb || items.boots) {
+				//Crystaroller Room
+				chests[6] = (items.firerod ? 'A' : 'P');
+
+				//Laser Bridge
+				chests[7] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+				chests[8] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+				chests[9] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+				chests[10] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+
+				//Boss
+				chests[11] = ConvertBossToChest(TRFrontBoss());
+			}
+
 		//3) Small Key shuffle only
 		} else if (!flags.wildbigkeys && flags.wildkeys) {
 			//Compass Chest
@@ -1329,21 +1352,23 @@
 					chests[4] = 'A';
 				
 					//Big Chest
-					chests[5] = (items.firerod ? 'K' : 'P'); //Reserved as big key, if fire rod made it accessable to this point
+					chests[5] = (items.bomb ? (items.firerod ? 'K' : 'P') : 'U'); //Reserved as big key, if fire rod made it accessable to this point
 					
-					//Crystaroller Room
-					chests[6] = (items.firerod ? 'A' : 'P');
-					
-					if (items.smallkey9 > 2) {
-						//Laser Bridge
-						chests[7] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-						chests[8] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-						chests[9] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
-						chests[10] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+					if (items.bomb || items.boots) {
+						//Crystaroller Room
+						chests[6] = (items.firerod ? 'A' : 'P');
 						
-						if (items.smallkey9 > 3) {
-							//Boss
-							chests[11] = ConvertBossToChest(TRFrontBoss());
+						if (items.smallkey9 > 2) {
+							//Laser Bridge
+							chests[7] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+							chests[8] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+							chests[9] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+							chests[10] = (items.firerod ? (items.lantern ? 'A' : 'DA') : (items.lantern ? 'P' : 'DP'));
+							
+							if (items.smallkey9 > 3) {
+								//Boss
+								chests[11] = ConvertBossToChest(TRFrontBoss());
+							}
 						}
 					}	
 				}
@@ -1367,9 +1392,9 @@
 			//Big Key Chest
 			chests[4] = (items.firerod ? 'K' : 'P'); //Reserved as third small key, regardless if the fire rod is accessable or not
 			
-			if (items.bigkey9) {
+			if (items.bigkey9 && (items.bomb || items.boots)) {
 				//Big Chest
-				chests[5] = (items.firerod ? 'A' : 'P'); //Reserved as big key, if fire rod made it accessable to this point
+				chests[5] = (items.bomb ? items.firerod ? 'A' : 'P' : 'U'); //Reserved as big key, if fire rod made it accessable to this point
 				
 				//Crystaroller Room
 				chests[6] = (items.firerod ? 'K' : 'P'); //Reserved as fourth small key
@@ -1404,9 +1429,9 @@
 					//Big Key Chest
 					chests[4] = 'A';
 					
-					if (items.bigkey9) {				
+					if (items.bigkey9 && (items.bomb || items.boots)) {				
 						//Big Chest
-						chests[5] = 'A';
+						chests[5] = (items.bomb ? 'A' : 'U');
 						
 						//Crystaroller Room
 						chests[6] = 'A';
@@ -1904,14 +1929,16 @@
 					//Firesnake Room - 0
 					chests[6] = 'K';  //Reserving as small key 3
 					
-					//Randomizer Room - Top Left - 1
-					chests[7] = 'A';
-					//Randomizer Room - Top Right - 1
-					chests[8] = 'A';
-					//Randomizer Room - Bottom Left - 1
-					chests[9] = 'A';
-					//Randomizer Room - Bottom Right - 1
-					chests[10] = 'A';
+					if (items.bomb) {
+						//Randomizer Room - Top Left - 1
+						chests[7] = 'A';
+						//Randomizer Room - Top Right - 1
+						chests[8] = 'A';
+						//Randomizer Room - Bottom Left - 1
+						chests[9] = 'A';
+						//Randomizer Room - Bottom Right - 1
+						chests[10] = 'A';
+					}
 				}			
 				
 				if (items.hookshot || items.boots) {
@@ -1925,12 +1952,15 @@
 				chests[11] = 'K'; //Reserving as big key
 				//Bob's Chest - 2
 				chests[12] = 'A';
-				//Big Key Chest - 2
-				chests[13] = 'A';
-				//Big Key Room - Left - 2
-				chests[14] = 'A';
-				//Big Key Room - Right - 2
-				chests[15] = 'A';
+
+				if (items.bomb) {
+					//Big Key Chest - 2
+					chests[13] = 'A';
+					//Big Key Room - Left - 2
+					chests[14] = 'A';
+					//Big Key Room - Right - 2
+					chests[15] = 'A';
+				}
 			}
 			
 			//Hope Room - Left - 0
@@ -1960,12 +1990,14 @@
 				chests[23] = 'A';
 				//Mini Helmasaur Room - Right - 3
 				chests[24] = 'A';
-				//Pre-Moldorm Chest - 3
-				chests[25] = 'A';
-				
-				if (items.hookshot) {
-					//Moldorm Chest
-					chests[26] = 'A';
+				if (items.bomb) {
+					//Pre-Moldorm Chest - 3
+					chests[25] = 'A';
+					
+					if (items.hookshot) {
+						//Moldorm Chest
+						chests[26] = 'A';
+					}
 				}
 			}
 		//2) Retro (w/ Big Key shuffle checks)
@@ -1988,14 +2020,16 @@
 					//Firesnake Room - 0
 					chests[6] = 'A';
 					
-					//Randomizer Room - Top Left - 1
-					chests[7] = 'A';
-					//Randomizer Room - Top Right - 1
-					chests[8] = 'A';
-					//Randomizer Room - Bottom Left - 1
-					chests[9] = 'A';
-					//Randomizer Room - Bottom Right - 1
-					chests[10] = 'A';
+					if (items.bomb) {
+						//Randomizer Room - Top Left - 1
+						chests[7] = 'A';
+						//Randomizer Room - Top Right - 1
+						chests[8] = 'A';
+						//Randomizer Room - Bottom Left - 1
+						chests[9] = 'A';
+						//Randomizer Room - Bottom Right - 1
+						chests[10] = 'A';
+					}
 				}			
 				
 				if (items.hookshot || items.boots) {
@@ -2009,12 +2043,15 @@
 				chests[11] = (flags.wildbigkeys ? (items.bigkey10 ? 'A' : 'U') : 'K'); //Reserving as big key
 				//Bob's Chest - 2
 				chests[12] = 'A';
-				//Big Key Chest - 2
-				chests[13] = 'A';
-				//Big Key Room - Left - 2
-				chests[14] = 'A';
-				//Big Key Room - Right - 2
-				chests[15] = 'A';
+
+				if (items.bomb) {
+					//Big Key Chest - 2
+					chests[13] = 'A';
+					//Big Key Room - Left - 2
+					chests[14] = 'A';
+					//Big Key Room - Right - 2
+					chests[15] = 'A';
+				}
 			}
 			
 			//Hope Room - Left - 0
@@ -2044,12 +2081,14 @@
 				chests[23] = 'A';
 				//Mini Helmasaur Room - Right - 3
 				chests[24] = 'A';
-				//Pre-Moldorm Chest - 3
-				chests[25] = 'A';
-				
-				if (items.hookshot) {
-					//Moldorm Chest
-					chests[26] = 'A';
+				if (items.bomb) {
+					//Pre-Moldorm Chest - 3
+					chests[25] = 'A';
+					
+					if (items.hookshot) {
+						//Moldorm Chest
+						chests[26] = 'A';
+					}
 				}
 			}
 		//3) Small Key shuffle only
@@ -2071,7 +2110,7 @@
 					//Firesnake Room - 0
 					chests[6] = 'A';
 					
-					if (items.smallkey10 > 0) {
+					if (items.smallkey10 > 0 && items.bomb) {
 						//Randomizer Room - Top Left - 1
 						chests[7] = 'A';
 						//Randomizer Room - Top Right - 1
@@ -2094,12 +2133,15 @@
 				chests[11] = 'K';
 				//Bob's Chest - 2
 				chests[12] = 'A';
-				//Big Key Chest - 2
-				chests[13] = 'A';
-				//Big Key Room - Left - 2
-				chests[14] = 'A';
-				//Big Key Room - Right - 2
-				chests[15] = 'A';
+
+				if (items.bomb) {
+					//Big Key Chest - 2
+					chests[13] = 'A';
+					//Big Key Room - Left - 2
+					chests[14] = 'A';
+					//Big Key Room - Right - 2
+					chests[15] = 'A';
+				}
 			}
 			
 			//Hope Room - Left - 0
@@ -2129,12 +2171,15 @@
 				chests[23] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
 				//Mini Helmasaur Room - Right - 3
 				chests[24] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
-				//Pre-Moldorm Chest - 3
-				chests[25] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
-				
-				if (items.hookshot) {
-					//Moldorm Chest - 3
-					chests[26] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
+
+				if (items.bomb) {
+					//Pre-Moldorm Chest - 3
+					chests[25] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
+					
+					if (items.hookshot) {
+						//Moldorm Chest - 3
+						chests[26] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
+					}
 				}
 			}
 		//4) Big Key shuffle only
@@ -2156,14 +2201,16 @@
 					//Firesnake Room - 0
 					chests[6] = 'K';  //Reserving as small key 3
 					
-					//Randomizer Room - Top Left - 1
-					chests[7] = 'A';
-					//Randomizer Room - Top Right - 1
-					chests[8] = 'A';
-					//Randomizer Room - Bottom Left - 1
-					chests[9] = 'A';
-					//Randomizer Room - Bottom Right - 1
-					chests[10] = 'A';
+					if (items.bomb) {
+						//Randomizer Room - Top Left - 1
+						chests[7] = 'A';
+						//Randomizer Room - Top Right - 1
+						chests[8] = 'A';
+						//Randomizer Room - Bottom Left - 1
+						chests[9] = 'A';
+						//Randomizer Room - Bottom Right - 1
+						chests[10] = 'A';
+					}
 				}			
 				
 				if (items.hookshot || items.boots) {
@@ -2177,12 +2224,15 @@
 				chests[11] = (items.bigkey10 ? 'A' : 'U');
 				//Bob's Chest - 2
 				chests[12] = 'A';
-				//Big Key Chest - 2
-				chests[13] = 'A';
-				//Big Key Room - Left - 2
-				chests[14] = 'A';
-				//Big Key Room - Right - 2
-				chests[15] = 'A';
+
+				if (items.bomb) {
+					//Big Key Chest - 2
+					chests[13] = 'A';
+					//Big Key Room - Left - 2
+					chests[14] = 'A';
+					//Big Key Room - Right - 2
+					chests[15] = 'A';
+				}
 			}
 			
 			//Hope Room - Left - 0
@@ -2212,12 +2262,15 @@
 				chests[23] = 'A';
 				//Mini Helmasaur Room - Right - 3
 				chests[24] = 'A';
-				//Pre-Moldorm Chest - 3
-				chests[25] = 'A';
-				
-				if (items.hookshot) {
-					//Moldorm Chest
-					chests[26] = 'A';
+
+				if (items.bomb) {
+					//Pre-Moldorm Chest - 3
+					chests[25] = 'A';
+					
+					if (items.hookshot) {
+						//Moldorm Chest
+						chests[26] = 'A';
+					}
 				}
 			}
 		//5) Small Key + Big Key shuffle
@@ -2239,7 +2292,7 @@
 					//Firesnake Room - 0
 					chests[6] = 'A';
 					
-					if (items.smallkey10 > 0) {
+					if (items.smallkey10 > 0 && items.bomb) {
 						//Randomizer Room - Top Left - 1
 						chests[7] = 'A';
 						//Randomizer Room - Top Right - 1
@@ -2262,12 +2315,15 @@
 				chests[11] = (items.bigkey10 ? 'A' : 'U');
 				//Bob's Chest - 2
 				chests[12] = 'A';
-				//Big Key Chest - 2
-				chests[13] = 'A';
-				//Big Key Room - Left - 2
-				chests[14] = 'A';
-				//Big Key Room - Right - 2
-				chests[15] = 'A';
+
+				if (items.bomb) {
+					//Big Key Chest - 2
+					chests[13] = 'A';
+					//Big Key Room - Left - 2
+					chests[14] = 'A';
+					//Big Key Room - Right - 2
+					chests[15] = 'A';
+				}
 			}
 			
 			//Hope Room - Left - 0
@@ -2297,22 +2353,18 @@
 				chests[23] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
 				//Mini Helmasaur Room - Right - 3
 				chests[24] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
-				//Pre-Moldorm Chest - 3
-				chests[25] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
-				
-				if (items.hookshot) {
-					//Moldorm Chest - 3
-					chests[26] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
+
+				if (items.bomb) {
+					//Pre-Moldorm Chest - 3
+					chests[25] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
+					
+					if (items.hookshot) {
+						//Moldorm Chest - 3
+						chests[26] = ((items.smallkey10 > 2 || flags.gametype == 'R') ? 'A' : 'P');
+					}
 				}
 			}
 		}		
-		
-		
-		
-		
-		
-		
-		
 		
 		if (flags.wildbigkeys || flags.wildkeys || flags.gametype === 'R') {
 			
@@ -2335,14 +2387,16 @@
 					//Firesnake Room - 0
 					chests[6] = 'K';  //Reserving as small key 3
 					
-					//Randomizer Room - Top Left - 1
-					chests[7] = 'A';
-					//Randomizer Room - Top Right - 1
-					chests[8] = 'A';
-					//Randomizer Room - Bottom Left - 1
-					chests[9] = 'A';
-					//Randomizer Room - Bottom Right - 1
-					chests[10] = 'A';
+					if (items.bomb) {
+						//Randomizer Room - Top Left - 1
+						chests[7] = 'A';
+						//Randomizer Room - Top Right - 1
+						chests[8] = 'A';
+						//Randomizer Room - Bottom Left - 1
+						chests[9] = 'A';
+						//Randomizer Room - Bottom Right - 1
+						chests[10] = 'A';
+					}
 				}			
 				
 				if (items.hookshot || items.boots) {
@@ -2356,12 +2410,15 @@
 				chests[11] = 'K';				
 				//Bob's Chest - 2
 				chests[12] = 'A';
-				//Big Key Chest - 2
-				chests[13] = 'A';
-				//Big Key Room - Left - 2
-				chests[14] = 'A';
-				//Big Key Room - Right - 2
-				chests[15] = 'A';
+
+				if (items.bomb) {
+					//Big Key Chest - 2
+					chests[13] = 'A';
+					//Big Key Room - Left - 2
+					chests[14] = 'A';
+					//Big Key Room - Right - 2
+					chests[15] = 'A';
+				}
 			}
 			
 			//Hope Room - Left - 0
@@ -2391,12 +2448,14 @@
 				chests[23] = 'A';
 				//Mini Helmasaur Room - Right - 3
 				chests[24] = 'A';
-				//Pre-Moldorm Chest - 3
-				chests[25] = 'A';
-				
-				if (items.hookshot) {
-					//Moldorm Chest
-					chests[26] = 'A';
+				if (items.bomb) {
+					//Pre-Moldorm Chest - 3
+					chests[25] = 'A';
+					
+					if (items.hookshot) {
+						//Moldorm Chest
+						chests[26] = 'A';
+					}
 				}
 			}
 		}

--- a/js/entrancechests.js
+++ b/js/entrancechests.js
@@ -755,7 +755,7 @@
 				return canReachInvertedLightWorld() ? 'available' : 'unavailable';
 			}
 		}, { // [38]
-			caption: 'Bomb Hut',
+			caption: 'Bomb Hut {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
@@ -991,7 +991,7 @@
 				return canReachInvertedLightWorldBunny() ? 'available' : 'unavailable';
 			}
 		}, { // [63]
-			caption: 'Mini Moldorm Cave',
+			caption: 'Mini Moldorm Cave {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
@@ -1013,7 +1013,7 @@
 				return items.flippers && canReachInvertedLightWorld() ? 'available' : 'unavailable';
 			}
 		}, { // [65]
-			caption: 'Ice Rod Cave',
+			caption: 'Ice Rod Cave {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
@@ -1246,7 +1246,7 @@
 				return canReachInvertedSouthDW() ? 'available' : 'unavailable';
 			}
 		}, { // [88]
-			caption: 'Hype Cave',
+			caption: 'Hype Cave {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
@@ -3951,7 +3951,7 @@
 				return (items.flippers ? 'available' : 'unavailable');
 			}
 		}, { // [6]
-			caption: 'Fairy Spring',
+			caption: 'Fairy Spring {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
@@ -4249,7 +4249,7 @@
 				return 'available';
 			}
 		}, { // [38]
-			caption: 'Bomb Hut',
+			caption: 'Bomb Hut {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
@@ -4482,7 +4482,7 @@
 				return 'available';
 			}
 		}, { // [63]
-			caption: 'Mini Moldorm Cave',
+			caption: 'Mini Moldorm Cave {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
@@ -4503,7 +4503,7 @@
 				return (items.flippers) ? 'available' : 'unavailable';
 			}
 		}, { // [65]
-			caption: 'Ice Rod Cave',
+			caption: 'Ice Rod Cave {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
@@ -4732,7 +4732,7 @@
 				return (canReachDarkWorldSouth() && items.boots && items.moonpearl) ? 'available' : 'unavailable';
 			}
 		}, { // [88]
-			caption: 'Hype Cave',
+			caption: 'Hype Cave {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
@@ -4962,7 +4962,7 @@
 				return (canReachOutcast() && items.moonpearl && items.hammer) ? 'available' : 'unavailable';
 			}
 		}, { // [111]
-			caption: 'Bombable Hut',
+			caption: 'Bombable Hut {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',

--- a/js/entrancechests.js
+++ b/js/entrancechests.js
@@ -25,6 +25,7 @@
     function melee_bow() { return melee() || items.bow > 0; }
     function cane() { return items.somaria || items.byrna; }
     function rod() { return items.firerod || items.icerod; }
+	function canHitSwitch() { return (melee_bow() || cane() || rod() || items.boomerang || items.hookshot || items.bomb); }
 	function agatowerweapon() { return items.sword > 0 || items.somaria || items.bow > 0 || items.hammer || items.firerod; }
 
     function always() { return 'available'; }
@@ -445,14 +446,14 @@
 				return items.flippers && canReachInvertedLightWorld() ? 'available' : 'unavailable';
 			}
 		}, { // [6]
-			caption: 'Fairy Spring',
+			caption: 'Fairy Spring {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
 			is_connector: false,
 			is_available: function() {
 				if (hasFoundEntrance(6)) return 'available';
-				return canReachInvertedLightWorld() ? 'available' : 'unavailable';
+				return canReachInvertedLightWorld() && items.bomb ? 'available' : 'unavailable';
 			}
 		}, { // [7]
 			caption: 'Hyrule Castle - Main Entrance',
@@ -761,7 +762,7 @@
 			is_connector: false,
 			is_available: function() {
 				if (hasFoundEntrance(38)) return 'available';
-				return canReachInvertedLightWorld() ? 'available' : 'unavailable';
+				return canReachInvertedLightWorld() && items.bomb ? 'available' : 'unavailable';
 			}
 		}, { // [39]
 			caption: 'Shop',
@@ -997,7 +998,7 @@
 			is_connector: false,
 			is_available: function() {
 				if (hasFoundEntrance(63)) return 'available';
-				return canReachInvertedLightWorld() ? 'available' : 'unavailable';
+				return canReachInvertedLightWorld() && items.bomb ? 'available' : 'unavailable';
 			}
 		}, { // [64]
 			caption: 'Pond of Happiness',
@@ -1019,7 +1020,7 @@
 			is_connector: false,
 			is_available: function() {
 				if (hasFoundEntrance(65)) return 'available';
-				return canReachInvertedLightWorld() ? 'available' : 'unavailable';
+				return canReachInvertedLightWorld() && items.bomb ? 'available' : 'unavailable';
 			}
 		}, { // [66]
 			caption: 'Good Bee Cave',
@@ -1251,7 +1252,7 @@
 			known_location: '',
 			is_connector: false,
 			is_available: function() {
-				return canReachInvertedSouthDW() ? 'available' : 'unavailable';
+				return canReachInvertedSouthDW() && items.bomb ? 'available' : 'unavailable';
 			}
 		}, { // [89]
 			caption: 'Swamp Palace',
@@ -1470,13 +1471,14 @@
 				return (items.hammer && canReachInvertedNorthDW()) ? 'available' : 'unavailable';
 			}
 		}, { // [111]
-			caption: 'Bombable Hut',
+			caption: 'Bombable Hut {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
 			is_connector: false,
 			is_available: function() {
-				return canReachInvertedNorthDW() ? 'available' : 'unavailable';
+				if (hasFoundEntrance(111)) return 'available';
+				return canReachInvertedNorthDW() && items.bomb ? 'available' : 'unavailable';
 			}
 		}, { // [112]
 			caption: 'Hammer Peg Cave',
@@ -1555,15 +1557,19 @@
 				return canReachInvertedSouthDW() ? 'available' : 'unavailable';
 			}
 		}, { // [120]
-			caption: 'Ledge Fairy',
+			caption: 'Ledge Fairy {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
 			is_connector: false,
 			is_available: function() {
-				if (hasFoundEntrance(120) || hasFoundEntrance(121) || hasFoundEntrance(122) || activeFluteInvertedEntrance()) return 'available';
-				if (items.mirror && canReachInvertedLightWorldBunny()) return 'available';
-				return (items.flippers && (canReachInvertedEastDW() || canReachInvertedSouthDW())) ? 'available' : 'unavailable';
+				if (hasFoundEntrance(120)) return 'available';
+				if (items.bomb) {
+					if (hasFoundEntrance(121) || hasFoundEntrance(122) || activeFluteInvertedEntrance()) return 'available';
+					if (items.mirror && canReachInvertedLightWorldBunny()) return 'available';
+					if (items.flippers && (canReachInvertedEastDW() || canReachInvertedSouthDW())) return 'available';
+				}
+				return 'unavailable';
 			}
 		}, { // [121]
 			caption: 'Ledge Hint',
@@ -3951,7 +3957,7 @@
 			known_location: '',
 			is_connector: false,
 			is_available: function() {
-				return 'available';
+				return (items.bomb ? 'available' : 'unavailable');
 			}
 		}, { // [7]
 			caption: 'Hyrule Castle - Main Entrance',
@@ -4249,7 +4255,8 @@
 			known_location: '',
 			is_connector: false,
 			is_available: function() {
-				return 'available';
+				if (hasFoundEntrance(46)) return 'available';				
+				return (items.bomb ? 'available' : 'unavailable');
 			}
 		}, { // [39]
 			caption: 'Shop',
@@ -4481,7 +4488,8 @@
 			known_location: '',
 			is_connector: false,
 			is_available: function() {
-				return 'available';
+				if (hasFoundEntrance(63)) return 'available';				
+				return (items.bomb ? 'available' : 'unavailable');
 			}
 		}, { // [64]
 			caption: 'Pond of Happiness',
@@ -4501,7 +4509,8 @@
 			known_location: '',
 			is_connector: false,
 			is_available: function() {
-				return 'available';
+				if (hasFoundEntrance(65)) return 'available';
+				return (items.bomb ? 'available' : 'unavailable');
 			}
 		}, { // [66]
 			caption: 'Good Bee Cave',
@@ -4730,7 +4739,7 @@
 			is_connector: false,
 			is_available: function() {
 				if (hasFoundEntrance(88)) return 'available';
-				return (canReachDarkWorldSouth() && items.moonpearl) ? 'available' : 'unavailable';
+				return (canReachDarkWorldSouth() && items.moonpearl && items.bomb) ? 'available' : 'unavailable';
 			}
 		}, { // [89]
 			caption: 'Swamp Palace',
@@ -4960,7 +4969,7 @@
 			is_connector: false,
 			is_available: function() {
 				if (hasFoundEntrance(111)) return 'available';
-				return (canReachOutcast() && items.moonpearl) ? 'available' : 'unavailable';
+				return (canReachOutcast() && items.moonpearl && items.bomb) ? 'available' : 'unavailable';
 			}
 		}, { // [112]
 			caption: 'Hammer Peg Cave',
@@ -5045,14 +5054,14 @@
 				return (canReachDarkWorldSouth()) ? 'available' : 'unavailable';
 			}
 		}, { // [120]
-			caption: 'Ledge Fairy',
+			caption: 'Ledge Fairy {bomb}',
 			is_opened: false,
 			note: '',
 			known_location: '',
 			is_connector: false,
 			is_available: function() {
 				if (hasFoundEntrance(120)) return 'available';
-				return (canReachDarkWorldSouthEast() && items.moonpearl) ? 'available' : 'unavailable';
+				return (canReachDarkWorldSouthEast() && items.moonpearl && items.bomb) ? 'available' : 'unavailable';
 			}
 		}, { // [121]
 			caption: 'Ledge Hint',

--- a/js/track.js
+++ b/js/track.js
@@ -1835,7 +1835,7 @@
 				document.getElementById('bigkey10').style.visibility = 'hidden';
 				document.getElementById('bigkeyhalf0').style.visibility = 'hidden';
 				document.getElementById('bigkeyhalf1').style.visibility = 'hidden';
-			} else {
+			} else if (document.getElementById('shuffledbigkeys').checked != flags.wildbigkeys) {
 				if (items.bigkey0) toggle('bigkey0');
 				if (items.bigkey1) toggle('bigkey1');
 				if (items.bigkey2) toggle('bigkey2');

--- a/js/track.js
+++ b/js/track.js
@@ -934,14 +934,14 @@
 					var connector2 = document.getElementById('entranceMap' + document.getElementById('entranceID').value);
 					
 					if (connector1.offsetTop > connector2.offsetTop) {
-						divtoadd.style.top = connector2.offsetTop + 6;
+						divtoadd.style.top = connector2.offsetTop + 5;
 					} else {
-						divtoadd.style.top = connector1.offsetTop + 6;
+						divtoadd.style.top = connector1.offsetTop + 5;
 					}
 					if (connector1.offsetLeft > connector2.offsetLeft) {
-						divtoadd.style.left = connector2.offsetLeft + 6;
+						divtoadd.style.left = connector2.offsetLeft + 5;
 					} else {
-						divtoadd.style.left = connector1.offsetLeft + 6;
+						divtoadd.style.left = connector1.offsetLeft + 5;
 					}
 					
 					if (connector1.offsetLeft > connector2.offsetLeft) {
@@ -2627,10 +2627,10 @@
 			window.addEventListener("message", receiveMessage, false);
 		
 		standardbombs = true;
-		if (flags.gametype != 'S') {
-			toggle('bomb');
-			standardbombs = false;
-		}
+//		if (flags.gametype != 'S') {
+//			toggle('bomb');
+//			standardbombs = false;
+//		}
 		
 		if (flags.entrancemode === 'N') {			
 			for (var i = 0; i < 10; i++) {


### PR DESCRIPTION
New version of DoorRando has a `--bomblogic` setting that enables starting with 0 bomb capacity. Upon finding a `Bomb Upgrade (+10)` in the item pool, your bombs come into logic.

This PR enables all the logic additions that come with bomblogic, and is implemented for all non-glitched modes (open/inverted/ER).

Some locations have gotten a `partialavailable` color to indicate that the player can get some items from there but that some require bombs or a weapon.

The implementation turns off the automatic bomb-enabling that non-standard modes though, and relies on the user or autotracker to track bomb inventory. I felt this was preferential over creating another checkbox that would essentially just do that. 

In addition to this there are a couple of minor improvements:
1. Connector lines was changed to a solid color rather than a gradient, and their alignment was adjusted to be better centered on the map icons.
2. Currently, when changing sanity-modes in Mystery, the tracker unclicks all Big Keys. I fixed that here.
 